### PR TITLE
Feat: Permite a configuração do campo 'tpObjeto' de forma explícita

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ $correios->price()->get(
           'height'      => 200,
           'width'       => 200,
           'diameter'    => 0,
-          'cubicWeight' => 0
+          'cubicWeight' => 0,
+          /** 1 - Envelope (Default); 2 - Caixa; 3 - Rolo*/
+          'objectType' => 2
         ]
     ],
     originCep:'71930000',

--- a/src/Includes/Product.php
+++ b/src/Includes/Product.php
@@ -10,6 +10,13 @@ class Product
     private float $length;
     private float $diameter;
     private float $cubicWeight;
+    /**
+     * @var int Tipo do objeto.
+     * 1 - Envelope (Default);
+     * 2 - Caixa;
+     * 3 - Rolo
+     */
+    private int $objectType;
 
     public function __construct(
         float $weight,
@@ -17,7 +24,8 @@ class Product
         float $height = 0,
         float $length = 0,
         float $diameter = 0,
-        float $cubicWeight = 0
+        float $cubicWeight = 0,
+        int   $objectType = 1
     ) {
         $this->weight      = $weight;
         $this->width       = $width;
@@ -25,6 +33,7 @@ class Product
         $this->length      = $length;
         $this->diameter    = $diameter;
         $this->cubicWeight = $cubicWeight;
+        $this->objectType  = $objectType;
     }
 
     public function getWeight(): float
@@ -55,5 +64,10 @@ class Product
     public function getCubicWeight(): float
     {
         return $this->cubicWeight;
+    }
+
+    public function getObjectType(): int
+    {
+        return $this->objectType;
     }
 }

--- a/src/Includes/Product.php
+++ b/src/Includes/Product.php
@@ -10,12 +10,6 @@ class Product
     private float $length;
     private float $diameter;
     private float $cubicWeight;
-    /**
-     * @var int Tipo do objeto.
-     * 1 - Envelope (Default);
-     * 2 - Caixa;
-     * 3 - Rolo
-     */
     private int $objectType;
 
     public function __construct(

--- a/src/Services/Price/Price.php
+++ b/src/Services/Price/Price.php
@@ -74,6 +74,10 @@ class Price extends AbstractRequest
             $productParam['cubicWeight'] = $product->getCubicWeight();
         }
 
+        if ($product->getObjectType() > 1 && $product->getObjectType() <= 3) {
+            $productParam['tpObjeto'] = $product->getObjectType();
+        }
+
         return $productParam;
     }
 
@@ -92,7 +96,8 @@ class Price extends AbstractRequest
                 $product['height'],
                 $product['length'],
                 $product['diameter'],
-                $product['cubicWeight']
+                $product['cubicWeight'],
+                $product['objectType'],
             );
         }
 
@@ -105,12 +110,13 @@ class Price extends AbstractRequest
             'height',
             'length',
             'diameter',
-            'cubicWeight'
+            'cubicWeight',
+            'objectType'
         ];
 
         foreach ($needed as $key) {
             if (!isset($product[$key]) || !is_numeric($product[$key])) {
-                $product[$key] = 0;
+                $product[$key] = $key == 'objectType' ? 1 : 0;
             }
         }
 


### PR DESCRIPTION
## Motivo

A API de cotação de preços de frete dos Correios aceita o envio do parâmetro `tpObjeto` para identificar o tipo de objeto que será utilizado para o envio do produto. Sendo as opções:

`1` - Envelope. Padrão utilizado quando o campo não é enviado na requisição;
`2` - Caixa;
`3` - Rolo.

O problema é que este parâmetro não é documentado na documentação oficial da API dos Correios, tornando complicado o uso do mesmo para quem está tendo o primeiro contato com a API.

## Solução

Adicionar este campo de forma explícita no produto, documentando as opções possíveis para que o mesmo fique compreensível para os usuários. Desta forma, o desenvolvedor terá acesso as opções disponíveis ao criar um novo produto.

```php
class Product
{
    ...
    /**
     * @var int Tipo do objeto.
     * 1 - Envelope (Default);
     * 2 - Caixa;
     * 3 - Rolo
     */
    private int $objectType;

    public function __construct(
        ...      
        int   $objectType = 1
    ) {
       ...
        $this->objectType  = $objectType;
    }
}
```