### PR TITLE
Update Authentication.php with DR and Contract

### DIFF
--- a/src/Services/Authorization/Authentication.php
+++ b/src/Services/Authorization/Authentication.php
@@ -9,6 +9,8 @@ class Authentication extends AbstractRequest
 {
     private string $username;
     private string $password;
+    private string $dr;
+    private object $cartaoPostagem;
     private string $contract;
     private string $token;
     private \DateTime $tokenExpiration;
@@ -17,6 +19,7 @@ class Authentication extends AbstractRequest
         $this->username = $username;
         $this->password = $password;
         $this->contract = $contract;
+        $this->cartaoPostagem = (object) [];
 
         $this->setEnvironment($isTestMode ? 'sandbox' : 'production');
         $this->setEndpoint('token/v1/autentica/cartaopostagem');
@@ -51,11 +54,31 @@ class Authentication extends AbstractRequest
                 $this->token = $data->token;
                 $this->tokenExpiration = new \DateTime($data->expiraEm);
             }
-
+            // Set DR and Contract
+            if (isset($data->cartaoPostagem->dr) && isset($data->cartaoPostagem->contrato)) {
+                $this->cartaoPostagem->dr = $data->cartaoPostagem->dr;
+                $this->cartaoPostagem->contract = $data->cartaoPostagem->contrato;
+            }
         } catch (ApiRequestException $e) {
             $this->errors[$e->getCode()] = $e->getMessage();
         }
     }
+
+    public function setCartaoPostagem(object $cartaoPostagem): void
+    {
+        $this->cartaoPostagem = $cartaoPostagem;
+    }
+
+    public function getDr(): string
+    {
+        return $this->cartaoPostagem->dr ?? '';
+    }
+
+    public function getContract(): string
+    {
+        return $this->cartaoPostagem->contract ?? '';
+    }
+
     public function getToken(): string
     {
         return $this->token ?? '';

--- a/tests/Unit/Services/Authorization/AuthenticationTest.php
+++ b/tests/Unit/Services/Authorization/AuthenticationTest.php
@@ -7,11 +7,13 @@ $username = fake()->userName();
 $contract = fake()->regexify('[0-9]{10}');
 $password = fake()->password();
 $token    = fake()->regexify('[0-9]{10}[A-Z]{5}[a-z]{5}');
+$dr       = fake()->regexify('[0-9]{10}');
 
 dataset('username', [$username]);
 dataset('password', [$password]);
 dataset('contract', [$contract]);
 dataset('token', [$token]);
+dataset('dr', [$dr]);
 
 test('It should be possible instance the authentication class without generate any errors in the array list', function(string $username, string $password, string $contract) {
     $authentication = new Authentication($username, $password, $contract, true);
@@ -128,6 +130,51 @@ describe('getResponseCode() method', function() {
         expect($authentication->getResponseCode())
             ->not->toBeNull()
             ->toBeInt();
+
+    })->with('username', 'password', 'contract');
+});
+
+
+describe('getDr() method', function() {
+    test('It should be possible to use the getDr() method', function(string $username, string $password, string $contract) {
+        $authentication = new Authentication($username, $password, $contract, true);
+        $authentication->getToken();
+
+        expect(fn() =>
+        $authentication->getDr()
+        )->not->toThrow(Exception::class);
+
+    })->with('username', 'password', 'contract');
+
+    test('The getDr() method must return a string', function(string $username, string $password, string $contract) {
+        $authentication = new Authentication($username, $password, $contract, true);
+        $authentication->getToken();
+
+        expect($authentication->getDr())
+            ->not->toBeNull()
+            ->toBeString();
+
+    })->with('username', 'password', 'contract');
+});
+
+describe('getContract() method', function() {
+    test('It should be possible to use the getContract() method', function(string $username, string $password, string $contract) {
+        $authentication = new Authentication($username, $password, $contract, true);
+        $authentication->getToken();
+        
+        expect(fn() =>
+        $authentication->getToken()
+        )->not->toThrow(Exception::class);
+
+    })->with('username', 'password', 'contract');
+
+    test('The getContract() method must return a string', function(string $username, string $password, string $contract) {
+        $authentication = new Authentication($username, $password, $contract, true);
+        $authentication->getToken();
+
+        expect($authentication->getContract())
+            ->not->toBeNull()
+            ->toBeString();
 
     })->with('username', 'password', 'contract');
 });


### PR DESCRIPTION
Para realizar o cálculo correto da estimativa, é necessário incluir o DR e o Contract nas consultas. Portanto, ao salvá-los no objeto Authentication, facilita-se a reutilização conforme a autenticação realizada.

Exemplo
```
$correios = new \Correios\Correios(
    username: 'user',
    password: 'password',
    postcard: 'postcard',
    isTestMode: true
);

$token           = $correios->authentication()->getToken();
$tokenExpiration = $correios->authentication()->getTokenExpiration();
$responseBody    = $correios->authentication()->getResponseBody();
$responseCode    = $correios->authentication()->getResponseCode();
$errors          = $correios->authentication()->getErrors();

$dr = $correios->authentication()->getDr();
$contract = $correios->authentication()->getContract();

// Parâmetros obrigatórios - Required Paramns
$correios->price()->get(
    serviceCodes:['04162'],
    products:[
        ['weight' => 300]
    ],
    originCep:'71930000',
    destinyCep:'05336010'
);

// Parâmetros opcionais - Optional parameters
$correios->price()->get(
    serviceCodes:['04162'],
    products:[
        [
          'weight'      => 300,
          'length'      => 0,
          'height'      => 200,
          'width'       => 200,
          'diameter'    => 0,
          'cubicWeight' => 0,
          /** 1 - Envelope (Default); 2 - Caixa; 3 - Rolo*/
          'objectType' => 2
        ]
    ],
    originCep:'71930000',
    destinyCep:'05336010',
    fields: [
        'nuContrato' => '0000000000', // Pode ser usado $correios->authentication()->getContract();
        'nuDR' => 20 // Pode ser usado $correios->authentication()->getDr();
    ]
);
```