### PR TITLE
Payload em pt-br para estimar preço

### DIFF
--- a/src/Services/Price/Price.php
+++ b/src/Services/Price/Price.php
@@ -55,23 +55,23 @@ class Price extends AbstractRequest
     private function setOptionalParams(Product $product, array $productParam): array
     {
         if ($product->getWidth() > 0) {
-            $productParam['width'] = $product->getWidth();
+            $productParam['largura'] = $product->getWidth();
         }
 
         if ($product->getHeight() > 0) {
-            $productParam['height'] = $product->getHeight();
+            $productParam['altura'] = $product->getHeight();
         }
 
         if ($product->getLength() > 0) {
-            $productParam['length'] = $product->getLength();
+            $productParam['comprimento'] = $product->getLength();
         }
 
         if ($product->getDiameter() > 0) {
-            $productParam['diameter'] = $product->getDiameter();
+            $productParam['diametro'] = $product->getDiameter();
         }
 
         if ($product->getCubicWeight() > 0) {
-            $productParam['cubicWeight'] = $product->getCubicWeight();
+            $productParam['psCubico'] = $product->getCubicWeight();
         }
 
         if ($product->getObjectType() > 1 && $product->getObjectType() <= 3) {

--- a/tests/Unit/Services/Price/PriceTest.php
+++ b/tests/Unit/Services/Price/PriceTest.php
@@ -55,6 +55,26 @@ describe('get() method', function() {
 
     })->with('authentication', 'serviceCode', 'originCep', 'destinyCep');
 
+    test('It should be possible to use the get() method with optional dimensions without generate any Exception or empty array', function(Authentication $authentication, string $serviceCode, string $originCep, string $destinyCep) {
+        $price = new Price($authentication, time());
+        expect(
+            fn() => $price->get(
+                [$serviceCode],
+                [[
+                    'weight' => fake()->randomFloat(1,1, 1000),
+                    'width' => fake()->randomFloat(1,10, 20),
+                    'height' => fake()->randomFloat(1,10, 20),
+                    'length' => fake()->randomFloat(1,10, 20),
+                ]],
+                $originCep,
+                $destinyCep
+            )
+        )
+        ->not->toBeEmpty()
+        ->not->toThrow(Exception::class);
+
+    })->with('authentication', 'serviceCode', 'originCep', 'destinyCep');
+
     test('The get() method should generate an InvalidCepException when we use an invalid CEP', function(Authentication $authentication, string $serviceCode, string $destinyCep) {
         $price = new Price($authentication, time());
         expect(


### PR DESCRIPTION
A estimativa estava retornando **array empty** quando passamos os parâmetros de dimensões dos produtos, isso por que as medidas no payload estavam sendo passadas em Inglês, mas a API dos Correios esperam receber em Português. 