### PR TITLE
Bugfix validação de CEP de origem e destino iguais

### DIFF
--- a/src/Includes/Traits/CepHandler.php
+++ b/src/Includes/Traits/CepHandler.php
@@ -12,7 +12,7 @@ trait CepHandler
     {
         $cleanCep = cep()->validate($cep);
 
-        if ($this->originCep === $cleanCep || $this->destinyCep === $cleanCep) {
+        if ($this->originCep === $cleanCep && $this->destinyCep === $cleanCep) {
             throw new SameCepException($cep);
         }
 


### PR DESCRIPTION
A validação não está passando, caso os dois CEPs sejam iguais as duas condições tem que retornar true.